### PR TITLE
Add W3WButtonWithIconAndText

### DIFF
--- a/Sources/W3WSwiftDesign/Views/Buttons/W3WButton.swift
+++ b/Sources/W3WSwiftDesign/Views/Buttons/W3WButton.swift
@@ -18,29 +18,53 @@ public class W3WButton: UIButton, W3WViewProtocol {
   public var position: W3WViewPosition?
 
   var icon: W3WIconView?
+  
+  /// font style of titleLabel
   var fontStyle: W3WFontStyle?
   
-  public init(image: W3WImage, fontStyle: W3WFontStyle? = nil, scheme: W3WScheme? = nil, position: W3WViewPosition? = nil, onTap: @escaping () -> () = { }) {
+  /// spacing between titleLabel and imageView, will just be applied when button has both image and text
+  var spacing: CGFloat?
+  
+  public init(image: W3WImage,
+              scheme: W3WScheme? = nil,
+              position: W3WViewPosition? = nil,
+              onTap: @escaping () -> () = { }) {
     super.init(frame: .w3wWhatever)
-    configure(icon: W3WIconView(image: image, scheme: scheme), fontStyle: fontStyle, scheme: scheme, position: position, onTap: onTap)
+    configure(icon: W3WIconView(image: image, scheme: scheme), scheme: scheme, position: position, onTap: onTap)
   }
   
 
-  public init(label: String, fontStyle: W3WFontStyle? = nil, scheme: W3WScheme? = nil, position: W3WViewPosition? = nil, onTap: @escaping () -> () = { }) {
+  public init(label: String, 
+              fontStyle: W3WFontStyle? = nil,
+              scheme: W3WScheme? = nil,
+              position: W3WViewPosition? = nil,
+              onTap: @escaping () -> () = { }) {
     super.init(frame: .w3wWhatever)
     configure(label: label, fontStyle: fontStyle, scheme: scheme, position: position, onTap: onTap)
   }
   
   
-  public init(icon: W3WIconView, label: String? = nil, fontStyle: W3WFontStyle? = nil, scheme: W3WScheme? = nil, position: W3WViewPosition? = nil, onTap: @escaping () -> () = { }) {
+  public init(icon: W3WIconView, 
+              label: String? = nil,
+              fontStyle: W3WFontStyle? = nil,
+              spacing: CGFloat? = W3WMargin.light.value,
+              scheme: W3WScheme? = nil,
+              position: W3WViewPosition? = nil,
+              onTap: @escaping () -> () = { }) {
     super.init(frame: .w3wWhatever)
-    configure(icon: icon, label: label, fontStyle: fontStyle, scheme: scheme, position: position, onTap: onTap)
+    configure(icon: icon, label: label, fontStyle: fontStyle, spacing: spacing, scheme: scheme, position: position, onTap: onTap)
   }
   
   
-  public init(image: W3WImage, label: String, fontStyle: W3WFontStyle? = nil, scheme: W3WScheme? = nil, position: W3WViewPosition? = nil, onTap: @escaping () -> () = { }) {
+  public init(image: W3WImage, 
+              label: String,
+              fontStyle: W3WFontStyle? = nil,
+              spacing: CGFloat? = nil,
+              scheme: W3WScheme? = nil,
+              position: W3WViewPosition? = nil,
+              onTap: @escaping () -> () = { }) {
     super.init(frame: .w3wWhatever)
-    configure(icon: W3WIconView(image: image, scheme: scheme), label: label, fontStyle: fontStyle, scheme: scheme, position: position, onTap: onTap)
+    configure(icon: W3WIconView(image: image, scheme: scheme), label: label, fontStyle: fontStyle, spacing: spacing, scheme: scheme, position: position, onTap: onTap)
   }
 
   
@@ -49,8 +73,15 @@ public class W3WButton: UIButton, W3WViewProtocol {
   }
 
   
-  func configure(icon: W3WIconView? = nil, label: String? = nil, fontStyle: W3WFontStyle? = nil, scheme: W3WScheme? = nil, position: W3WViewPosition? = nil, onTap: @escaping () -> () = { }) {
+  func configure(icon: W3WIconView? = nil, 
+                 label: String? = nil,
+                 fontStyle: W3WFontStyle? = nil,
+                 spacing: CGFloat? = nil,
+                 scheme: W3WScheme? = nil,
+                 position: W3WViewPosition? = nil,
+                 onTap: @escaping () -> () = { }) {
     self.fontStyle = fontStyle
+    self.spacing = spacing
     
     set(scheme: scheme, position: position)
     
@@ -119,12 +150,34 @@ public class W3WButton: UIButton, W3WViewProtocol {
     setTitleColor(scheme?.colors?.foreground?.current.uiColor ?? fallbackColor, for: .focused)
     setTitleColor(scheme?.colors?.secondary?.current.uiColor ?? fallbackColor, for: .selected)
     
-    imageView?.tintColor = scheme?.colors?.tint?.current.uiColor
-    if let insets = scheme?.styles?.padding?.insets {
-      contentEdgeInsets = insets
-    }
+    // Apply foreground color to imageView so image and text have the same color
+    imageView?.tintColor = scheme?.colors?.foreground?.current.uiColor
+    
     if let fontStyle = fontStyle, let font = scheme?.styles?.fonts?[fontStyle] {
       titleLabel?.font = font
     }
+        
+    if let spacing = spacing, icon != nil && !(titleLabel?.text?.isEmpty ?? true) {
+      // If button has both image and title, set space between them
+      centerTextAndImage(spacing: spacing, insets: scheme?.styles?.padding?.insets ?? .zero)
+    } else {
+      contentEdgeInsets = scheme?.styles?.padding?.insets ?? .zero
+    }
+  }
+}
+
+
+extension UIButton {
+  func centerTextAndImage(spacing: CGFloat, insets: UIEdgeInsets) {
+    let insetAmount = spacing / 2.0
+    let isRTL = semanticContentAttribute == .forceRightToLeft
+    if isRTL {
+      imageEdgeInsets = UIEdgeInsets(top: 0, left: insetAmount, bottom: 0, right: -insetAmount)
+      titleEdgeInsets = UIEdgeInsets(top: 0, left: -insetAmount, bottom: 0, right: insetAmount)
+    } else {
+      imageEdgeInsets = UIEdgeInsets(top: 0, left: -insetAmount, bottom: 0, right: insetAmount)
+      titleEdgeInsets = UIEdgeInsets(top: 0, left: insetAmount, bottom: 0, right: -insetAmount)
+    }
+    contentEdgeInsets = UIEdgeInsets(top: insets.top, left: insetAmount + insets.left, bottom: insets.bottom, right: insetAmount + insets.right)
   }
 }

--- a/Sources/W3WSwiftDesign/Views/Buttons/W3WButtonWithIconAndText.swift
+++ b/Sources/W3WSwiftDesign/Views/Buttons/W3WButtonWithIconAndText.swift
@@ -1,0 +1,77 @@
+//
+//  W3WButtonWithIconAndText.swift
+//  
+//
+//  Created by Thy Nguyen on 03/04/2024.
+//
+
+import UIKit
+import W3WSwiftCore
+
+public final class W3WButtonWithIconAndText: W3WButton {
+  /// Custom height for button, if it's not specified then button height will be dependent on its intrinsic size
+  private let height: CGFloat?
+  
+  /// Custom image size based on button custom height and scheme's padding
+  private var imageSize: CGSize?
+  
+  public init(image: W3WImage, 
+              label: String,
+              height: CGFloat? = nil,
+              fontStyle: W3WFontStyle? = nil,
+              spacing: CGFloat? = nil,
+              scheme: W3WScheme? = nil,
+              onTap: @escaping () -> Void = {}) {
+    self.height = height
+    super.init(image: image, label: label, fontStyle: fontStyle, spacing: spacing, scheme: scheme, onTap: onTap)
+    self.spacing = spacing
+    configure()
+  }
+  
+  public init(icon: W3WIconView,
+              label: String,
+              height: CGFloat? = nil,
+              fontStyle: W3WFontStyle? = nil,
+              spacing: CGFloat? = nil,
+              scheme: W3WScheme? = nil,
+              onTap: @escaping () -> () = { }) {
+    self.height = height
+    super.init(icon: icon, label: label, fontStyle: fontStyle, spacing: spacing, scheme: scheme, onTap: onTap)
+    self.spacing = spacing
+    configure()
+  }
+  
+  private func configure() {
+    translatesAutoresizingMaskIntoConstraints = false
+    imageView?.contentMode = .scaleAspectFit
+    if let height = height {
+      imageSize = .init(width: height, height: height)
+      NSLayoutConstraint.activate([
+        heightAnchor.constraint(equalToConstant: height),
+      ])
+    } else {
+      imageSize = icon?.underlyingImage.get().size
+    }
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func set(scheme: W3WScheme?) {
+    self.scheme = scheme
+    if let height = height, let insets = scheme?.styles?.padding {
+      let size = height - insets.value * 2.0
+      imageSize = .init(width: size, height: size)
+    }
+    update(scheme: scheme)
+    icon?.set(scheme: scheme)
+    if let i = icon {
+      if let imageSize = imageSize {
+        setImage(i.asImage(size: .init(value: imageSize)), for: .normal)
+      } else {
+        setImage(i.asImage(), for: .normal)
+      }
+    }
+  }
+}

--- a/Sources/W3WSwiftDesign/Views/Buttons/W3WCloseButton.swift
+++ b/Sources/W3WSwiftDesign/Views/Buttons/W3WCloseButton.swift
@@ -22,7 +22,7 @@ public class W3WCloseButton: W3WButton {
     self.inset = inset
     self.roundedCorners = roundedCorners
     
-    let colors = W3WColors(foreground: .clear, tint: .white)
+    let colors = W3WColors(foreground: .white)
     
     let styles: W3WStyles = .standard
       .with(visualEffect: W3WVisualEffect(style: .thin,
@@ -51,7 +51,7 @@ public class W3WCloseButton: W3WButton {
     self.inset = inset
     self.roundedCorners = roundedCorners
     
-    let colors = W3WColors(foreground: .clear, tint: .white)
+    let colors = W3WColors(foreground: .white)
     
     let styles: W3WStyles = .standard
       .with(visualEffect: W3WVisualEffect(style: .thin,

--- a/Sources/W3WSwiftDesign/Views/Images/W3WIconView.swift
+++ b/Sources/W3WSwiftDesign/Views/Images/W3WIconView.swift
@@ -101,13 +101,13 @@ public class W3WIconView: UIImageView, W3WViewProtocol {
   
   
   /// convert this view into a UIImage
-  public func asImage() -> UIImage? {
-    return underlyingImage.get()
+  public func asImage(size: W3WIconSize? = nil) -> UIImage? {
+    return underlyingImage.get(size: size)
   }
 
   
   public func updateImage(size: W3WIconSize? = nil) {
-    self.image = underlyingImage.get()
+    self.image = underlyingImage.get(size: size)
   }
   
   


### PR DESCRIPTION
A button with both image and text can be created using `W3WButtonWithIconAndText` like this:
```
lazy var w3wButton: W3WButtonWithIconAndText = {
    let icon: W3WIconView = W3WIconView(image: .camera)
    let button = W3WButtonWithIconAndText(icon: icon, label: "a button with image and text", height: 100.0)
    return button
}()
```
Then we can set a scheme for it:
```
let scheme: W3WScheme = .standard.with(foreground: .white)
w3wButton.set(scheme: scheme)
```