### PR TITLE
Release w3w-swift-design v1.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "w3w-swift-core",
         "repositoryURL": "https://github.com/what3words/w3w-swift-core.git",
         "state": {
-          "branch": null,
-          "revision": "3e2e9859f3e7b42640fd12a689bcab26dadf19e4",
-          "version": "1.1.5"
+          "branch": "staging",
+          "revision": "1e38676bf065d6c3411895fe2c47bab04c56bba0",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     
     dependencies: [
-      .package(url: "https://github.com/what3words/w3w-swift-core.git", branch: "staging"),
+      .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.3.0"..<"2.0.0"),
       .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0"..<"2.0.0")
     ],
     

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     
     dependencies: [
-      .package(url: "https://github.com/what3words/w3w-swift-core.git", "1.0.0"..<"2.0.0"),
+      .package(url: "https://github.com/what3words/w3w-swift-core.git", branch: "staging"),
       .package(url: "https://github.com/what3words/w3w-swift-themes.git", "1.0.0"..<"2.0.0")
     ],
     


### PR DESCRIPTION
## Summary

Promotes `staging` into `main` to cut release **v1.3.0** (minor bump from v1.2.0).

### What's included
- Pinned `w3w-swift-core` dependency from `branch:"staging"` to `"1.3.0"..<"2.0.0"`.
- Package updates (Package.resolved refresh).

### Scope
2 commits, 2 files changed (+4 / -4).